### PR TITLE
Upgrade to java 9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     working_directory: ~/Pokkit
 
     docker:
-      - image: circleci/openjdk:8-jdk-browsers
+      - image: circleci/openjdk:9-jdk-browsers
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pokkit
+# Pokkit [![CircleCI](https://circleci.com/gh/PetteriM1/Pokkit.svg?style=svg)](https://circleci.com/gh/PetteriM1/Pokkit)
 
 The Minecraft multiplayer scene is fragmented. There are many competing server implementations. A popular server is [Spigot](http://www.spigotmc.org/). Spigot is able to load plugins, which can interact with Minecraft through the Spigot Plugin API. For Minecraft Pocket Edition, the mobile version of Minecraft, a server with a plugin API similar to Spigot exists: [Nukkit](https://nukkitx.com/). Unfortunately, plugins written for Spigot cannot run on Nukkit.
 


### PR DESCRIPTION
Fixes an annoying error with Maven's go-offline plugin (apparently
that doesn't work with java 8?):

    Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test) on project Pokkit: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test failed: The forked VM terminated without saying properly goodbye. VM crash or System.exit called ?